### PR TITLE
fix: Changed deployment, image and helathcheck port to new default prometheus 5000

### DIFF
--- a/.github/workflows/build-forwarder.yaml
+++ b/.github/workflows/build-forwarder.yaml
@@ -107,11 +107,18 @@ jobs:
         run: |
           docker build -f ./AKSKubeAuditReceiverSolution/AKSKubeAuditReceiver/Dockerfile \
             ./AKSKubeAuditReceiverSolution --tag sysdiglabs/aks-audit-log-forwarder
-      - name: Sysdig Secure inline image scan
-        uses: sysdiglabs/scan-action@v2
+      - name: Scan image
+        id: scan
+        uses: sysdiglabs/scan-action@v3
         with:
           image-tag: "sysdiglabs/aks-audit-log-forwarder"
           sysdig-secure-token: ${{ secrets.KUBELAB_SECURE_API_TOKEN }}
+          input-type: docker-daemon
+          run-as-user: root
+      - uses: github/codeql-action/upload-sarif@v1
+        if: always()
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarifReport }}
 
   publish_image:
     name: Publish container image to registries

--- a/.github/workflows/build-forwarder.yaml
+++ b/.github/workflows/build-forwarder.yaml
@@ -142,8 +142,9 @@ jobs:
           VERSION_TAG: ${{ github.event.release.tag_name }}
         run: |
           echo "Version tag: $VERSION_TAG"
-          VERSION_MAJOR=$(echo $VERSION_TAG | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-          VERSION_FULL=$(echo $VERSION_TAG | sed 's/[^0-9]*\([0-9]\+.*\)/\1/')
+          VERSION_MAJOR=$(echo $VERSION_TAG | sed 's/v\([0-9]*\).*/\1/' )
+          VERSION_FULL=$(echo $VERSION_TAG | sed 's/v\([0-9][0-9\.]*\).*/\1/' )
+          [ -z $VERSION_TAG ] && VERSION_FULL="master"
           [ -z $VERSION_FULL ] && VERSION_FULL="master"
           [ -z $VERSION_MAJOR ] && VERSION_MAJOR="dev"
           echo "Version major: $VERSION_MAJOR"

--- a/.github/workflows/build-forwarder.yaml
+++ b/.github/workflows/build-forwarder.yaml
@@ -134,8 +134,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.SYSDIGLABS_DOCKERHUB_USER }}
+          password: ${{ secrets.SYSDIGLABS_DOCKERHUB_TOKEN }}
       - name: Prepare version labels
         id: prepare_version_labels
         env:

--- a/.github/workflows/build-installer.yaml
+++ b/.github/workflows/build-installer.yaml
@@ -101,9 +101,17 @@ jobs:
         id: run_sysdig_inline_scan
         env:
           SYSDIG_SECURE_TOKEN: ${{ secrets.KUBELAB_SECURE_API_TOKEN }}
-        run: |
-          docker run sysdiglabs/secure-inline-scan:2 -s https://secure.sysdig.com -k $SYSDIG_SECURE_TOKEN sysdiglabs/aks-audit-log-installer \
-            | tee sysdig_image_scan_result.txt
+        run: |          
+          docker run --rm \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              quay.io/sysdig/secure-inline-scan:2 \
+              --sysdig-url https://secure.sysdig.com \
+              --sysdig-token "$SYSDIG_SECURE_TOKEN" \
+              --storage-type docker-daemon \
+              --storage-path /var/run/docker.sock \
+              sysdiglabs/aks-audit-log-installer \
+              | tee sysdig_image_scan_result.txt
+
           SCAN_RESULT=${PIPESTATUS[0]}
           echo "::set-output name=SCAN_RESULT::$SCAN_RESULT"
           echo "Scan finished with result: $SCAN_RESULT"
@@ -158,9 +166,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            sysdiglabs/aks-audit-log-installer:latest
-            sysdiglabs/aks-audit-log-installer:${{ steps.prepare_version_labels.outputs.VERSION_MAJOR }}
-            sysdiglabs/aks-audit-log-installer:${{ steps.prepare_version_labels.outputs.VERSION_FULL }}
+            quay.io/sysdig/aks-audit-log-installer:latest
+            quay.io/sysdig/aks-audit-log-installer:${{ steps.prepare_version_labels.outputs.VERSION_MAJOR }}
+            quay.io/sysdig/aks-audit-log-installer:${{ steps.prepare_version_labels.outputs.VERSION_FULL }}
       - name: Login to GitHub Packages
         if: github.event_name == 'release'
         uses: docker/login-action@v1 

--- a/.github/workflows/build-installer.yaml
+++ b/.github/workflows/build-installer.yaml
@@ -150,8 +150,9 @@ jobs:
           VERSION_TAG: ${{ github.event.release.tag_name }}
         run: |
           echo "Version tag: $VERSION_TAG"
-          VERSION_MAJOR=$(echo $VERSION_TAG | sed 's/[^0-9]*\([0-9]\+\).*/\1/')
-          VERSION_FULL=$(echo $VERSION_TAG | sed 's/[^0-9]*\([0-9]\+.*\)/\1/')
+          VERSION_MAJOR=$(echo $VERSION_TAG | sed 's/v\([0-9]*\).*/\1/' )
+          VERSION_FULL=$(echo $VERSION_TAG | sed 's/v\([0-9][0-9\.]*\).*/\1/' )
+          [ -z $VERSION_TAG ] && VERSION_FULL="master"
           [ -z $VERSION_FULL ] && VERSION_FULL="master"
           [ -z $VERSION_MAJOR ] && VERSION_MAJOR="dev"
           echo "Version major: $VERSION_MAJOR"

--- a/.github/workflows/build-installer.yaml
+++ b/.github/workflows/build-installer.yaml
@@ -142,8 +142,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.SYSDIGLABS_DOCKERHUB_USER }}
+          password: ${{ secrets.SYSDIGLABS_DOCKERHUB_TOKEN }}
       - name: Prepare version labels
         id: prepare_version_labels
         env:

--- a/AKSKubeAuditReceiverSolution/AKSKubeAuditReceiver/Dockerfile
+++ b/AKSKubeAuditReceiverSolution/AKSKubeAuditReceiver/Dockerfile
@@ -36,9 +36,9 @@ RUN addgroup \
 
 RUN chown -R $USER:$USER .
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD wget localhost:1234/metrics -q -O - > /dev/null 2>&1
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD wget localhost:5000/metrics -q -O - > /dev/null 2>&1
 
 #Prometheus port
-EXPOSE 1234
+EXPOSE 5000
 
 ENTRYPOINT ["dotnet", "AKSKubeAuditReceiver.dll"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION_TAG=$(shell git describe --tags $(git rev-list --tags --max-count=1))
-VERSION_MAJOR=$(shell echo "${VERSION_TAG}"  | sed 's/[^0-9]*\([0-9]\+.*\)/\1/' )
-VERSION_FULL=$(shell echo "${VERSION_TAG}"   | sed 's/[^0-9]*\([0-9]\+\).*/\1/' )
+VERSION_MAJOR=$(shell echo "${VERSION_TAG}"  | sed 's/v\([0-9]*\).*/\1/' )
+VERSION_FULL=$(shell echo "${VERSION_TAG}"   | sed 's/v\([0-9][0-9\.]*\).*/\1/' )
 
 INSTALLER_IMAGE=sysdiglabs/aks-audit-log-installer
 INSTALLER_DIR=./
@@ -132,8 +132,9 @@ all-tests: check build test-gh-actions
 
 show-version:
 	@echo "Version tag: ${VERSION_TAG}"
-	@echo "Version full: ${VERSION_FULL}"
 	@echo "Version major: ${VERSION_MAJOR}"
+	@echo "Version full: ${VERSION_FULL}"
+	
 
 build-image:
 	docker build ${IMAGE_DIR} -f ${IMAGE_DOCKERFILE} \

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,18 @@ VERSION_TAG=$(shell git describe --tags $(git rev-list --tags --max-count=1))
 VERSION_MAJOR=$(shell echo "${VERSION_TAG}"  | sed 's/[^0-9]*\([0-9]\+.*\)/\1/' )
 VERSION_FULL=$(shell echo "${VERSION_TAG}"   | sed 's/[^0-9]*\([0-9]\+\).*/\1/' )
 
-INSTALLER_IMAGE=aks-audit-log-installer
+INSTALLER_IMAGE=sysdiglabs/aks-audit-log-installer
 INSTALLER_DIR=./
 INSTALLER_DESC=${INSTALLER_DIR}/build/README.md
 INSTALLER_DOCKERFILE=${INSTALLER_DIR}/build/Dockerfile
 
-FORWARDER_IMAGE=aks-audit-log-forwarder
+FORWARDER_IMAGE=sysdiglabs/aks-audit-log-forwarder
 FORWARDER_DIR=./AKSKubeAuditReceiverSolution
 FORWARDER_DESC=${FORWARDER_DIR}/AKSKubeAuditReceiver/README.md
 FORWARDER_DOCKERFILE=${FORWARDER_DIR}/AKSKubeAuditReceiver/Dockerfile
 
 DOCKERHUB_USERNAME=$(shell cat ${KEYS}/DOCKER_USER)
 DOCKERHUB_PASSWORD=$(shell cat ${KEYS}/DOCKER_PASS)
-DOCKERHUB_ORG=sysdiglabs
 
 GITHUB_USER=$(shell cat ${KEYS}/GH_USER)
 GITHUB_PAT_PATH="${KEYS}/GH_PAT_PKG"
@@ -29,21 +28,21 @@ SYSDIG_SECURE_API_TOKEN=$(shell cat ${KEYS}/SYSDIG_SECURE_API_TOKEN)
 
 installer-build-image: IMAGE_DIR=${INSTALLER_DIR}
 installer-build-image: IMAGE_DOCKERFILE=${INSTALLER_DOCKERFILE}
-installer-build-image: IMAGE=${DOCKERHUB_ORG}/${INSTALLER_IMAGE}
+installer-build-image: IMAGE=${INSTALLER_IMAGE}
 installer-build-image: build-image
 
 installer-build-push-dev:
-	docker build ${INSTALLER_DIR} -f ${INSTALLER_DOCKERFILE} -t ${DOCKERHUB_ORG}/${INSTALLER_IMAGE}:dev
-	docker push ${DOCKERHUB_ORG}/${INSTALLER_IMAGE}:dev
+	docker build ${INSTALLER_DIR} -f ${INSTALLER_DOCKERFILE} -t ${INSTALLER_IMAGE}:dev
+	docker push ${INSTALLER_IMAGE}:dev
 
-installer-scan: IMAGE=${DOCKERHUB_ORG}/${INSTALLER_IMAGE}
+installer-scan: IMAGE=${INSTALLER_IMAGE}
 installer-scan: inline-scan
 
-installer-dockerhub-readme: IMAGE=${DOCKERHUB_ORG}/${INSTALLER_IMAGE}
+installer-dockerhub-readme: IMAGE=${INSTALLER_IMAGE}
 installer-dockerhub-readme: DESC_PATH=${INSTALLER_DESC}
 installer-dockerhub-readme: update-dockerhub-readme
 
-installer-push: IMAGE=${DOCKERHUB_ORG}/${INSTALLER_IMAGE}
+installer-push: IMAGE=${INSTALLER_IMAGE}
 installer-push: check-shell installer-build-image installer-scan push
 
 installer-gh-pkg-release: IMAGE_NAME=${INSTALLER_IMAGE}
@@ -58,21 +57,21 @@ forwarder-test: check-yaml check-dotnet
 
 forwarder-build-image: IMAGE_DIR=${FORWARDER_DIR}
 forwarder-build-image: IMAGE_DOCKERFILE=${FORWARDER_DOCKERFILE}
-forwarder-build-image: IMAGE=${DOCKERHUB_ORG}/${FORWARDER_IMAGE}
+forwarder-build-image: IMAGE=${FORWARDER_IMAGE}
 forwarder-build-image: build-image
 
 forwarder-build-push-dev:
-	docker build ${FORWARDER_DIR} -f ${FORWARDER_DOCKERFILE} -t ${DOCKERHUB_ORG}/${FORWARDER_IMAGE}:dev
-	docker push ${DOCKERHUB_ORG}/${FORWARDER_IMAGE}:dev
+	docker build ${FORWARDER_DIR} -f ${FORWARDER_DOCKERFILE} -t ${FORWARDER_IMAGE}:dev
+	docker push ${FORWARDER_IMAGE}:dev
 
 forwarder-scan: IMAGE=${FORWARDER_IMAGE}
 forwarder-scan: inline-scan
 
-forwarder-dockerhub-readme: IMAGE=${DOCKERHUB_ORG}/${FORWARDER_IMAGE}
+forwarder-dockerhub-readme: IMAGE=${FORWARDER_IMAGE}
 forwarder-dockerhub-readme: DESC_PATH=${FORWARDER_DESC}
 forwarder-dockerhub-readme: update-dockerhub-readme
 
-forwarder-push: IMAGE=${DOCKERHUB_ORG}/${FORWARDER_IMAGE}
+forwarder-push: IMAGE=${FORWARDER_IMAGE}
 forwarder-push: forwarder-test forwarder-build forwarder-build-image forwarder-scan push
 
 forwarder-gh-pkg-release: IMAGE_NAME=${FORWARDER_IMAGE}
@@ -82,13 +81,13 @@ forwarder-gh-pkg-release: fowarder-test forwarder-build forwarder-build-image fo
 
 install:
 	docker run -it -v ${HOME}/.azure:/root/.azure \
-		${DOCKERHUB_ORG}/${INSTALLER_IMAGE}:${MINOR} \
+		${INSTALLER_IMAGE}:${MINOR} \
 		-g ${RESOURCE_GROUP} -c ${CLUSTER_NAME}
 
 uninstall:
 	docker run -it -v ${HOME}/.azure:/root/.azure \
 		--entrypoint /app/uninstall-aks-audit-log.sh \
-		${DOCKERHUB_ORG}/${INSTALLER_IMAGE}:${MINOR} \
+		${INSTALLER_IMAGE}:${MINOR} \
 		-g ${RESOURCE_GROUP} -c ${CLUSTER_NAME}
 
 # -----------------------------------------------------------------------------
@@ -138,15 +137,15 @@ show-version:
 
 build-image:
 	docker build ${IMAGE_DIR} -f ${IMAGE_DOCKERFILE} \
-		-t ${DOCKERHUB_ORG}/${IMAGE}:latest \
-		-t ${DOCKERHUB_ORG}/${IMAGE}:dev \
-		-t ${DOCKERHUB_ORG}/${IMAGE}:${VERSION_FULL} \
-		-t ${DOCKERHUB_ORG}/${IMAGE}:${VERSION_MAJOR}
+		-t ${IMAGE}:latest \
+		-t ${IMAGE}:dev \
+		-t ${IMAGE}:${VERSION_FULL} \
+		-t ${IMAGE}:${VERSION_MAJOR}
 
 push:
-	docker push ${DOCKERHUB_ORG}/${IMAGE}:latest
-	docker push ${DOCKERHUB_ORG}/${IMAGE}:${VERSION_FULL}
-	docker push ${DOCKERHUB_ORG}/${IMAGE}:${VERSION_MAJOR}
+	docker push ${IMAGE}:latest
+	docker push ${IMAGE}:${VERSION_FULL}
+	docker push ${IMAGE}:${VERSION_MAJOR}
 
 update-dockerhub-readme-docker:
 	echo 'Updating Dockerhub description' ; \

--- a/deployment.yaml.in
+++ b/deployment.yaml.in
@@ -37,13 +37,13 @@ spec:
             exec:
               command:
                 - wget
-                - localhost:1234/metrics
+                - localhost:5000/metrics
                 - --spider
             initialDelaySeconds: 10
           livenessProbe:
             httpGet:
               path: /metrics
-              port: 1234
+              port: 5000
             initialDelaySeconds: 10
             periodSeconds: 20
           env:

--- a/test/create-infra.sh
+++ b/test/create-infra.sh
@@ -2,6 +2,9 @@
 
 # set -uf
 
+my_resource_group="${RESOURCE_GROUP:-aks-test-group}"
+my_cluster_name="${CLUSTER_NAME:-aks-test-cluster}"
+
 echo "Create infra"
 echo "Resource group: $my_resource_group"
 echo "Cluster name: $my_cluster_name"
@@ -27,9 +30,10 @@ while [ $result -eq 1 ] && [ $i -gt 0 ]; do
     #result=$?
     i=$((i-1))
     sleep 2
-    #echo -n "."
+    echo -n "."
 done
 
+echo
 az aks show --resource-group "$my_resource_group" --name "$my_cluster_name"  --query provisioningState -o tsv
 echo
 

--- a/test/generate-dev-deployment.sh
+++ b/test/generate-dev-deployment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+my_resource_group="${RESOURCE_GROUP:-aks-test-group}"
+my_cluster_name="${CLUSTER_NAME:-aks-test-cluster}"
+
 echo "Resource group: $my_resource_group"
 echo "Cluster name: $my_cluster_name"
 

--- a/test/install-agent.sh
+++ b/test/install-agent.sh
@@ -2,6 +2,9 @@
 
 set -euf
 
+my_resource_group="${RESOURCE_GROUP:-aks-test-group}"
+my_cluster_name="${CLUSTER_NAME:-aks-test-cluster}"
+
 echo "Getting Kubectl credentials"
 az aks get-credentials --name "$my_cluster_name" --resource-group "$my_resource_group" --overwrite-existing
 

--- a/test/install.sh
+++ b/test/install.sh
@@ -2,9 +2,12 @@
 
 set -euf
 
+my_resource_group="${RESOURCE_GROUP:-aks-test-group}"
+my_cluster_name="${CLUSTER_NAME:-aks-test-cluster}"
+my_namespace="${SYSDIG_NAMESPACE:-sysdig-agent}"
+
 echo "Resource group: $my_resource_group"
 echo "Cluster name: $my_cluster_name"
 
-
-../install-aks-audit-log.sh -g $my_resource_group -c $my_cluster_name -n my-sysdig-agent  --yes
+../install-aks-audit-log.sh -g "$my_resource_group" -c "$my_cluster_name" -n "$my_namespace"  --yes
 

--- a/test/set-globals.fish
+++ b/test/set-globals.fish
@@ -2,9 +2,10 @@
 
 set -x ran (cat /dev/random | LC_ALL=C tr -dc "[:alpha:]" | head -c 8)
 
-set -Ux my_resource_group AKSAuditLogTest-Group-"$ran"
-set -Ux my_cluster_name AKSAuditLogTest-Cluster-"$ran"
-set -Ux my_sysdig_namespace my-sysdig-agent
+set -Ux RESOURCE_GROUP AKSAuditLogTest-Group-"$ran"
+set -Ux CLUSTER_NAME AKSAuditLogTest-Cluster-"$ran"
+set -Ux SYSDIG_NAMESPACE sysdig-agent
 
-echo "Resource group: $my_resource_group"
-echo "Cluster name: $my_cluster_name"
+echo "Resource group: $RESOURCE_GROUP"
+echo "Cluster name: $CLUSTER_NAME"
+echo "Sysdig namespace: $SYSDIG_NAMESPACE"

--- a/test/uninstall.sh
+++ b/test/uninstall.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+my_resource_group="${RESOURCE_GROUP:-aks-test-group}"
+my_cluster_name="${CLUSTER_NAME:-aks-test-cluster}"
+my_namespace="${SYSDIG_NAMESPACE:-sysdig-agent}"
+
 echo "Resource group: $my_resource_group"
 echo "Cluster name: $my_cluster_name"
 echo
 
-../uninstall-aks-audit-log.sh -g $my_resource_group -c $my_cluster_name -n my-sysdig-agent --yes
+../uninstall-aks-audit-log.sh -g "$my_resource_group" -c "$my_cluster_name" -n "$my_namespace" --yes
 
 


### PR DESCRIPTION
The forwared binary previously published Prometheus metrics on port 1234. This was changed to 5000 in the binary, but other resources like the image exposed port, deployment, and liveness probe were still pointing to 1234.