### PR TITLE
update az command

### DIFF
--- a/install-aks-audit-log.sh
+++ b/install-aks-audit-log.sh
@@ -210,9 +210,10 @@ function create_event_hubs {
     step=$((step + 1))
     echo "Creating Event Hub: $hub_name"
     az eventhubs eventhub create --name "$hub_name" \
+        --cleanup-policy Delete \
         --namespace-name "$ehubs_name" \
         --resource-group "$resource_group" \
-        --message-retention 1 \
+        --retention-time 1 \
         --partition-count 4 \
         --output none
 


### PR DESCRIPTION
Azure CLI has changed the `az eventhubs eventhub create` command option for retention to `--retention-time`. 

From the [docs](https://learn.microsoft.com/en-us/cli/azure/eventhubs/eventhub?view=azure-cli-latest)
"`--retention-time --retention-time-in-hours`
Number of hours to retain the events for this Event Hub. This value is only used when cleanupPolicy is Delete. If cleanupPolicy is Compaction the returned value of this property is Long.MaxValue."