### PR TITLE
Deployment fixes

### DIFF
--- a/deployment.yaml.in
+++ b/deployment.yaml.in
@@ -37,7 +37,7 @@ spec:
             exec:
               command:
                 - wget
-                - localhost:5000/metrics
+                - 127.0.0.1:5000/metrics
                 - --spider
             initialDelaySeconds: 10
           livenessProbe:

--- a/install-aks-audit-log.sh
+++ b/install-aks-audit-log.sh
@@ -287,7 +287,7 @@ function create_deployment {
     export BlobStorageConnectionString="$blob_connection_string"
     export VerboseLevel="3"
     export ImagePullPolicy="IfNotPresent"
-    export ImageVersion="0.1.3"
+    export ImageVersion="1.2.7"
 
     curl https://raw.githubusercontent.com/sysdiglabs/aks-kubernetes-audit-log/master/deployment.yaml.in |
       envsubst > "$WORKDIR/deployment.yaml"


### PR DESCRIPTION
Fix couple of minor things that were preventing proper deployment:
- Use 127.0.0.1 for the healthcheck instead of localhost because in some environments resolution defaults to IP6, so localhost was resolved to ::1 while the socket is only bound to IP4 address
- Bump to the latest image version